### PR TITLE
Additional documentation regarding critical css support in DDEV

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -310,6 +310,14 @@ return [
 ];
 ```
 
+If you’re using the [rollup-plugin-critical](https://github.com/nystudio107/rollup-plugin-critical) to generate [critical CSS](https://nystudio107.com/blog/implementing-critical-css), you must add extra Debian packages to enable Puppeteer Headless Chrome support. Add the following line to your `/.ddev/config.yaml` file:
+
+```yaml
+webimage_extra_packages: [gconf-service, libasound2, libatk1.0-0, libcairo2, libgconf-2-4, libgdk-pixbuf2.0-0, libgtk-3-0, libnspr4, libpango-1.0-0, libpangocairo-1.0-0, libx11-xcb1, libxcomposite1, libxcursor1, libxdamage1, libxfixes3, libxi6, libxrandr2, libxrender1, libxss1, libxtst6, fonts-liberation, libappindicator1, libnss3, xdg-utils]
+```
+
+Then in your `rollup.config.js`, be sure to set `criticalUrl` to `http://localhost`.
+
 ### Vite-Processed Assets
 
 This is cribbed from the [Laravel Vite integration](https://laravel-vite.netlify.app/guide/usage.html#static-assets) docs:

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -316,7 +316,7 @@ If you’re using the [rollup-plugin-critical](https://github.com/nystudio107/ro
 webimage_extra_packages: [gconf-service, libasound2, libatk1.0-0, libcairo2, libgconf-2-4, libgdk-pixbuf2.0-0, libgtk-3-0, libnspr4, libpango-1.0-0, libpangocairo-1.0-0, libx11-xcb1, libxcomposite1, libxcursor1, libxdamage1, libxfixes3, libxi6, libxrandr2, libxrender1, libxss1, libxtst6, fonts-liberation, libappindicator1, libnss3, xdg-utils]
 ```
 
-Then in your `rollup.config.js`, be sure to set `criticalUrl` to `http://localhost`.
+Then be sure to set `criticalUrl` to `http://localhost` as part of your rollup configuration.
 
 ### Vite-Processed Assets
 


### PR DESCRIPTION
Added the following based off of Discord feedback.

I decided to **not** link to the original documentation regarding adding puppeteer support to DDEV (https://github.com/drud/ddev-contrib/blob/master/recipes/puppeteer-headless-chrome-support/README.md), because the rest of the page provided potentially misleading information. Namely, it recommends using `https://demo.ddev.site`, whereas our recommendation is to use `http://localhost`.