### PR TITLE
Add support for detecting dev-mode in Craft CMS v4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.0.28 - 2022.07.31
+### Added
+* Added support for detecting dev-mode in Craft CMS v4 by changing `App::env('ENVIRONMENT') === 'dev'` 
+* to `App::env('ENVIRONMENT') === 'dev' || App::env('CRAFT_ENVIRONMENT') === 'dev'` ([#41](https://github.com/nystudio107/craft-vite/pull/41))
+
 ## 1.0.27 - 2022.07.16
 ### Changed
 * Fixed an issue where `checkDevServer` didn't work with Vite 3, because they removed the intercepting of `__vite_ping` ([#37](https://github.com/nystudio107/craft-vite/issues/37))

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -65,7 +65,7 @@ to `vite.php` and copied to your `config/` directory to take effect.
 use craft\helpers\App;
 
 return [
-    'useDevServer' => App::env('ENVIRONMENT') === 'dev', # For Craft CMS 4.x use `App::env('CRAFT_ENVIRONMENT') === 'dev'`
+    'useDevServer' => App::env('ENVIRONMENT') === 'dev' || App::env('CRAFT_ENVIRONMENT') === 'dev',
     'manifestPath' => '@webroot/dist/manifest.json',
     'devServerPublic' => 'http://localhost:3000/',
     'serverPublic' => App::env('PRIMARY_SITE_URL') . '/dist/',
@@ -375,7 +375,7 @@ return [
 	'devServerInternal' => 'http://localhost:3000',
 	'devServerPublic' => App::env('PRIMARY_SITE_URL') . ':3000',
 	'serverPublic' => App::env('PRIMARY_SITE_URL') . '/dist/',
-	'useDevServer' => App::env('ENVIRONMENT') === 'dev',
+	'useDevServer' => App::env('ENVIRONMENT') === 'dev' || App::env('CRAFT_ENVIRONMENT') === 'dev',
 	// other config settings...
 ];
 ```

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -65,7 +65,7 @@ to `vite.php` and copied to your `config/` directory to take effect.
 use craft\helpers\App;
 
 return [
-    'useDevServer' => App::env('ENVIRONMENT') === 'dev',
+    'useDevServer' => App::env('ENVIRONMENT') === 'dev', # For Craft CMS 4.x use `App::env('CRAFT_ENVIRONMENT') === 'dev'`
     'manifestPath' => '@webroot/dist/manifest.json',
     'devServerPublic' => 'http://localhost:3000/',
     'serverPublic' => App::env('PRIMARY_SITE_URL') . '/dist/',

--- a/src/config.php
+++ b/src/config.php
@@ -29,7 +29,7 @@ return [
    /**
     * @var bool Should the dev server be used?
     */
-    'useDevServer' => App::env('ENVIRONMENT') === 'dev',
+    'useDevServer' => App::env('ENVIRONMENT') === 'dev' || App::env('CRAFT_ENVIRONMENT') === 'dev',
 
     /**
      * @var string File system path (or URL) to the Vite-built manifest.json


### PR DESCRIPTION
### Description

I've spent way too long on trying to debug why Vite wasn't working when I found out that it was actually the plugin that wasn't properly configured. Changing the env var solved it. 

**Changes**

- Added support for detecting dev-mode in Craft CMS v4 in default config.php and the documentation: `App::env('ENVIRONMENT') === 'dev' || App::env('CRAFT_ENVIRONMENT') === 'dev'`

Please let me know if you agree or not. Thanks a bunch for this plugin !

### Related issues
none
