### PR TITLE
[Docs] Fixed default Vite server port

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -158,7 +158,7 @@ export default ({command}) => ({
 
 #### Specifying the dev server port
 
-Prior to version 3, Vite used port `3000` by default for the dev server. Now it uses port `5137` by default, so we can specify the port we want to use specifically:
+Prior to version 3, Vite used port `3000` by default for the dev server. Now it uses port `5173` by default, so we can specify the port we want to use specifically:
 
 ```js
 export default ({command}) => ({


### PR DESCRIPTION
### Description

The documentation incorrectly states Vite's default server port as `5137` instead of `5173`.
Source: https://vitejs.dev/config/server-options.html#server-port

### Related issues

N/A