### PR TITLE
docs: update ddev docker-compose snippet

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -348,8 +348,8 @@ services:
     expose:
       - '3000'
     environment:
-      - HTTP_EXPOSE=${DDEV_ROUTER_HTTP_PORT}:80,${DDEV_MAILHOG_PORT}:8025,3001:3000
-      - HTTPS_EXPOSE=${DDEV_ROUTER_HTTPS_PORT}:80,${DDEV_MAILHOG_HTTPS_PORT}:8025,3000:3000
+      - HTTP_EXPOSE=${DDEV_ROUTER_HTTP_PORT}:80,${DDEV_MAILPIT_PORT}:8025,3001:3000
+      - HTTPS_EXPOSE=${DDEV_ROUTER_HTTPS_PORT}:80,${DDEV_MAILPIT_HTTPS_PORT}:8025,3000:3000
 ```
 
 In your `vite.config.js`, the `server.host` should to be set to `0.0.0.0`, and `server.port` set to `3000`:


### PR DESCRIPTION
### Description
DDEV version 1.22.2 no longer uses MailHog, and replaced it with MailPit (https://github.com/ddev/ddev/pull/5313), so this snippet has to be updated or DDEV will not start correctly

### Related issues
