### PR TITLE
Craft Cloud: docs & deploy event

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
     "nystudio107/craft-plugin-vite": "^4.0.9"
   },
   "require-dev": {
+    "craftcms/cloud": "^1.37",
     "craftcms/ecs": "dev-main",
     "craftcms/phpstan": "dev-main",
     "craftcms/rector": "dev-main"

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -913,34 +913,43 @@ So for example:
 
 ## Craft Cloud
 
-Craft Cloud deploys build artifacts to a CDN, so you'll need to configure the plugin to use the CDN URL:
+During a [build](https://craftcms.com/knowledge-base/cloud-builds), Craft Cloud deploys static assets to a CDN, so you’ll need to configure the plugin to use the appropriate URLs:
 
 ```php
 <?php
 // config/vite.php
+
+use craft\cloud\Helper as CloudHelper;
+
 return [
-    'manifestPath' => \craft\cloud\Helper::artifactUrl('dist/manifest.json'),
-    'serverPublic' => \craft\cloud\Helper::artifactUrl('dist/'),
+    'manifestPath' => CloudHelper::artifactUrl('dist/.vite/manifest.json'),
+    'serverPublic' => CloudHelper::artifactUrl('dist/'),
 ];
 ```
 
-The `\craft\cloud\Helper::artifactUrl()` function will return a URL like
-`https://cdn.craft.com/{uuid}/builds/{uuid}/artifacts/dist/` in a Craft Cloud environment, and `@web/dist/` otherwise.
+This helper function returns a CDN URL that includes your project and environment identifiers, like this:
 
-If you'd like to use a different path all together when working locally,
-you can use the `\craft\cloud\Helper::isCraftCloud()`:
+```
+https://cdn.craft.com/{project-uuid}/builds/{environment-uuid}/artifacts/dist/
+```
+
+Outside of Cloud, this behaves as though it were prepended with `@web`.
+
+If you’d prefer to use an on-disk `manifestPath` when working locally (instead of a URL), the `CloudHelper::isCraftCloud()` function lets you switch based on the environment:
 
 ```php
 <?php
 // config/vite.php
+
+use craft\cloud\Helper as CloudHelper;
+
 return [
-    'manifestPath' => \craft\cloud\Helper::isCraftCloud() ? \craft\cloud\Helper::artifactUrl('dist/manifest.json') : '@webroot/dist/manifest.json',
-    'publicPath' => \craft\cloud\Helper::artifactUrl('dist/'),
+    'manifestPath' => CloudHelper::isCraftCloud() ? CloudHelper::artifactUrl('dist/.vite/manifest.json') : '@webroot/dist/.vite/manifest.json',
+    'serverPublic' => CloudHelper::artifactUrl('dist/'),
 ];
 ```
 
-Additionally, your Vite config should have [`base`](https://vitejs.dev/config/shared-options.html#base) set to use the same CDN URL.
-In Craft Cloud's build pipeline, this is exposed as an `CRAFT_CLOUD_ARTIFACT_BASE_URL` environment variable.
+Additionally, your Vite config should have [public `base`](https://vitejs.dev/guide/build.html#public-base-path) set to use the same CDN URL. In Craft Cloud’s build pipeline, this is exposed as an [`CRAFT_CLOUD_ARTIFACT_BASE_URL` environment variable](https://craftcms.com/knowledge-base/cloud-builds#build-command):
 
 ```javascript
 // vite.config.js

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -911,6 +911,44 @@ So for example:
     ) }}
 ```
 
+## Craft Cloud
+
+Craft Cloud deploys build artifacts to a CDN, so you'll need to configure the plugin to use the CDN URL:
+
+```php
+<?php
+// config/vite.php
+return [
+    'manifestPath' => \craft\cloud\Helper::artifactUrl('dist/manifest.json'),
+    'serverPublic' => \craft\cloud\Helper::artifactUrl('dist/'),
+];
+```
+
+The `\craft\cloud\Helper::artifactUrl()` function will return a URL like
+`https://cdn.craft.com/{uuid}/builds/{uuid}/artifacts/dist/` in a Craft Cloud environment, and `@web/dist/` otherwise.
+
+If you'd like to use a different path all together when working locally,
+you can use the `\craft\cloud\Helper::isCraftCloud()`:
+
+```php
+<?php
+// config/vite.php
+return [
+    'manifestPath' => \craft\cloud\Helper::isCraftCloud() ? \craft\cloud\Helper::artifactUrl('dist/manifest.json') : '@webroot/dist/manifest.json',
+    'publicPath' => \craft\cloud\Helper::artifactUrl('dist/'),
+];
+```
+
+Additionally, your Vite config should have [`base`](https://vitejs.dev/config/shared-options.html#base) set to use the same CDN URL.
+In Craft Cloud's build pipeline, this is exposed as an `CRAFT_CLOUD_ARTIFACT_BASE_URL` environment variable.
+
+```javascript
+// vite.config.js
+export default ({ command }) => ({
+  base: command === 'serve' ? '' : `${process.env.CRAFT_CLOUD_ARTIFACT_BASE_URL || ''}/dist/`,
+})
+```
+
 ## Vite Roadmap
 
 Some things to do, and ideas for potential features:

--- a/src/Vite.php
+++ b/src/Vite.php
@@ -13,6 +13,8 @@ namespace nystudio107\vite;
 use Craft;
 use craft\base\Model;
 use craft\base\Plugin;
+use craft\cloud\cli\controllers\UpController;
+use craft\events\CancelableEvent;
 use craft\events\RegisterCacheOptionsEvent;
 use craft\events\TemplateEvent;
 use craft\utilities\ClearCaches;
@@ -146,6 +148,17 @@ class Vite extends Plugin
                 self::$templateName = $event->template;
             }
         );
+        // Clears cache after craft cloud/up is run, which Craft Cloud runs on deploy
+        // Handler: UpController::EVENT_AFTER_UP
+        if (class_exists(UpController::class)) {
+            Event::on(
+                UpController::class,
+                UpController::EVENT_AFTER_UP,
+                function (CancelableEvent $event) {
+                    $this->clearAllCaches();
+                }
+            );
+        }
     }
 
     /**


### PR DESCRIPTION
- Adds Craft Cloud docs and examples
- Listens for a deploy event and clears cache

/cc @augustmiller