### PR TITLE
Update docs for DDEV usage

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -373,6 +373,9 @@ server: {
   port: 3000, 
   strictPort: true,
   origin: `${process.env.DDEV_PRIMARY_URL}:3000`
+  server: {
+    cors: process.env.DDEV_PRIMARY_URL,
+  }
 }
 ```
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -373,9 +373,7 @@ server: {
   port: 3000, 
   strictPort: true,
   origin: `${process.env.DDEV_PRIMARY_URL}:3000`
-  server: {
-    cors: process.env.DDEV_PRIMARY_URL,
-  }
+  cors: process.env.DDEV_PRIMARY_URL,
 }
 ```
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -372,7 +372,7 @@ server: {
   host: '0.0.0.0',
   port: 3000, 
   strictPort: true,
-  origin: `${process.env.DDEV_PRIMARY_URL}:3000`
+  origin: `${process.env.DDEV_PRIMARY_URL}:3000`,
   cors: {
     origin: process.env.DDEV_PRIMARY_URL
   }

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -367,14 +367,14 @@ A `ddev restart` is necessary afterwards.
 
 In your `vite.config.js`, the `server.host`should to be set to `0.0.0.0` and `server.port` set to (strict) port `3000`. It is also important to set the correct origin URL for [Vite-processed assets](https://nystudio107.com/docs/vite/#vite-processed-assets):
 
-```
+```js
 server: {
   host: '0.0.0.0',
   port: 3000, 
   strictPort: true,
   origin: `${process.env.DDEV_PRIMARY_URL}:3000`,
   cors: {
-    origin: process.env.DDEV_PRIMARY_URL
+    origin: /https?:\/\/([A-Za-z0-9\-\.]+)?(localhost|\.local|\.test|\.site)(?::\d+)?$/
   }
 }
 ```

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -373,7 +373,9 @@ server: {
   port: 3000, 
   strictPort: true,
   origin: `${process.env.DDEV_PRIMARY_URL}:3000`
-  cors: process.env.DDEV_PRIMARY_URL,
+  cors: {
+    origin: process.env.DDEV_PRIMARY_URL
+  }
 }
 ```
 


### PR DESCRIPTION
### Description

- add info about `web_extra_exposed_ports` (https://ddev.readthedocs.io/en/stable/users/extend/customization-extendibility/#exposing-extra-ports-via-ddev-router)
- add origin to `vite.config.js` and set it to DDEV primary url
- add info about changed manifest path in Vite >= v5

### Related issues

Thanks very much for providing this as Open Source!