### PR TITLE
docs: Update DDEV usage - set .ddev.site explicitly for server.cors.origin, add support for custom https_router_port for server.origin

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -391,11 +391,11 @@ use craft\helpers\App;
 return [
 	'checkDevServer' => true,
 	'devServerInternal' => 'http://localhost:3000',
-	'devServerPublic' => App::env('PRIMARY_SITE_URL') . ':3000',
+	'devServerPublic' => preg_replace('/:\d+$/', '', App::env('PRIMARY_SITE_URL')) . ':3000',
 	'serverPublic' => App::env('PRIMARY_SITE_URL') . '/dist/',
 	'useDevServer' => App::env('ENVIRONMENT') === 'dev' || App::env('CRAFT_ENVIRONMENT') === 'dev',
 
-        // for Vite v4 and below
+  // for Vite v4 and below
 	// 'manifestPath' => '@webroot/dist/manifest.json',
 	
 	// for Vite >= v5

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -372,10 +372,10 @@ server: {
   host: '0.0.0.0',
   port: 3000, 
   strictPort: true,
-  origin: `${process.env.DDEV_PRIMARY_URL}:3000`,
+  origin: `${process.env.DDEV_PRIMARY_URL.replace(/:\d+$/, "")}:3000`,
   cors: {
-    origin: /https?:\/\/([A-Za-z0-9\-\.]+)?(localhost|\.local|\.test|\.site)(?::\d+)?$/
-  }
+    origin: /https?:\/\/([A-Za-z0-9\-\.]+)?(\.ddev\.site)(?::\d+)?$/,
+  },
 }
 ```
 
@@ -397,7 +397,7 @@ return [
 
         // for Vite v4 and below
 	// 'manifestPath' => '@webroot/dist/manifest.json',
-
+	
 	// for Vite >= v5
 	'manifestPath' => '@webroot/dist/.vite/manifest.json'
 
@@ -423,6 +423,8 @@ web_environment:
 ```
 
 Then be sure to set `criticalUrl` to `http://localhost` as part of your rollup configuration.
+
+For more information about DDEV and Vite, see [Working with Vite in DDEV](https://ddev.com/blog/working-with-vite-in-ddev/).
 
 Finally note that as of DDEV 1.19 you are able to specify Node.js (and Composer) versions directly via `/.ddev/config.yaml`.  See more at https://ddev.readthedocs.io/en/stable/users/cli-usage/#nodejs-npm-nvm-and-yarn
 


### PR DESCRIPTION
### Description

Changes:

1. use `\.ddev\.site` explicitly for regex for `server.cors.origin`, as [proposed by vitejs core maintainer](https://github.com/ddev/ddev.com/pull/313#discussion_r1942642297) - otherwise the attack surface is still open via sites with `.site` TLD

2. support custom `router-https-port` (test via `ddev config --router-https-port 8443 && ddev restart` - `process.env.DDEV_PRIMARY_URL` will then output "https://my-project.ddev.site:8443". Therefore we need to strip out 8443 first, before setting the `server.origin` setting. This is also relevant because DDEV auto-selects a router port if 80/443 is already occupied since last year (https://ddev.com/blog/release-v1235-auto-port-assignment/). This needs a tiny change in `config/vite.php` as well.

3. add info about official article about Vite on ddev.com (https://ddev.com/blog/working-with-vite-in-ddev/) where users find out more information and where DDEV maintainers try to keep all further infos up-to-date. 

Hope this will be it, fingers crossed. Thanks very much for providing this plugin!

(Demo repo with this config is available here: https://github.com/mandrasch/ddev-craftcms-vite)

### Related issues

- https://github.com/ddev/ddev.com/pull/313
- https://github.com/nystudio107/craft-vite/pull/92