### PR TITLE
Update craftcms/cloud version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "nystudio107/craft-plugin-vite": "^5.0.2"
   },
   "require-dev": {
-    "craftcms/cloud": "^2.0.0",
+    "craftcms/cloud": "^2.0.0 || ^3.0.0",
     "craftcms/ecs": "dev-main",
     "craftcms/phpstan": "dev-main",
     "craftcms/rector": "dev-main"


### PR DESCRIPTION
`craftcms/cloud:3.0.0` has been released and is a non-breaking from the consumer's end.

### Description



### Related issues
